### PR TITLE
Add search box to CardSelect

### DIFF
--- a/src/components/common/CardDrawer.tsx
+++ b/src/components/common/CardDrawer.tsx
@@ -78,6 +78,7 @@ const CardDrawer = <TCard extends Card>({
           onSelect={onSelectCard}
           canRemove={!!selectedCard}
           onRemove={onRemoveCard}
+          open={open}
         />
       </DialogContent>
     </ResponsiveDrawer>

--- a/src/components/common/CardDrawer.tsx
+++ b/src/components/common/CardDrawer.tsx
@@ -47,7 +47,7 @@ const CardDrawer = <TCard extends Card>({
       open={open}
       onClose={onClose}
       sx={{
-        "--Drawer-verticalSize": "min(571px, 65%)",
+        "--Drawer-verticalSize": "100%",
       }}
     >
       <ModalClose />
@@ -66,20 +66,21 @@ const CardDrawer = <TCard extends Card>({
         )}
       </DialogTitle>
       <DialogContent sx={{ m: 1.5 }}>
-        <CardSelect
-          sx={{ height: "100%" }}
-          cards={cards}
-          cardName={cardName}
-          onCardNameChange={setCardName}
-          gameBox={gameBox}
-          onGameBoxChange={setGameBox}
-          treeSymbol={treeSymbol}
-          onTreeSymbolChange={setTreeSymbol}
-          onSelect={onSelectCard}
-          canRemove={!!selectedCard}
-          onRemove={onRemoveCard}
-          open={open}
-        />
+        {open && (
+          <CardSelect
+            sx={{ height: "100%" }}
+            cards={cards}
+            cardName={cardName}
+            onCardNameChange={setCardName}
+            gameBox={gameBox}
+            onGameBoxChange={setGameBox}
+            treeSymbol={treeSymbol}
+            onTreeSymbolChange={setTreeSymbol}
+            onSelect={onSelectCard}
+            canRemove={!!selectedCard}
+            onRemove={onRemoveCard}
+          />
+        )}
       </DialogContent>
     </ResponsiveDrawer>
   );

--- a/src/components/common/CardSelect.tsx
+++ b/src/components/common/CardSelect.tsx
@@ -1,18 +1,19 @@
 import * as _ from "lodash-es";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import EditIcon from "@mui/icons-material/Edit";
 import ClearIcon from "@mui/icons-material/Clear";
+import EditIcon from "@mui/icons-material/Edit";
+import SearchIcon from "@mui/icons-material/Search";
 import {
   Button,
   IconButton,
+  Input,
   List,
   ListItem,
   ListSubheader,
   Stack,
   Typography,
-  Input,
 } from "@mui/joy";
 import { SxProps } from "@mui/joy/styles/types";
 
@@ -93,7 +94,6 @@ interface CardSelectProps<TCard extends Card> {
   onSelect?: (value: TCard) => void;
   canRemove?: boolean;
   onRemove?: () => void;
-  open?: boolean;
 }
 
 const CardSelect = <TCard extends Card>({
@@ -108,20 +108,21 @@ const CardSelect = <TCard extends Card>({
   onSelect,
   canRemove = false,
   onRemove,
-  open,
 }: CardSelectProps<TCard>) => {
   const intl = useIntl();
 
-  const [search, setSearch] = useState('');
+  const [search, setSearch] = useState("");
+
+  const matchingCards = cards.filter((card) =>
+    getLocalizedCardName(intl, card.name)
+      ?.toLowerCase()
+      ?.includes(search.toLowerCase()),
+  );
 
   const cardNameOptions = getOptions(
-    cards,
+    matchingCards,
     (c) => c.name,
     (n) => getLocalizedCardName(intl, n) ?? n,
-  ).filter(card =>
-    getLocalizedCardName(intl, card.name)!
-      .toLowerCase()
-      .includes(search.toLowerCase())
   );
 
   const cardNameOptionsByType = _.groupBy(
@@ -200,7 +201,7 @@ const CardSelect = <TCard extends Card>({
   };
 
   const handleSelectCardName = (value: TCard) => {
-    clearSearch();
+    handleClearSearch();
     handleSelect(value.name);
   };
 
@@ -227,17 +228,16 @@ const CardSelect = <TCard extends Card>({
     onGameBoxChange(undefined);
   };
 
-  const searchRef = useRef<HTMLDivElement>(null);
+  const handleClearSearch = () => {
+    setSearch("");
+  };
 
-  const clearSearch = () => {
-    setSearch('')
-  }
-
-  useEffect(() => {
-    if (open) {
-      searchRef.current?.querySelector('input')!.focus();
-    }
-  }, [searchRef, open])
+  const showSubheaders =
+    new Set(
+      cards
+        .flatMap((c) => c.types)
+        .filter((t) => !EXPANSION_CARD_TYPES.includes(t)),
+    ).size > 1;
 
   return (
     <Stack direction="column" gap={2} justifyContent="space-between" sx={sx}>
@@ -262,17 +262,38 @@ const CardSelect = <TCard extends Card>({
             </IconButton>
           </Stack>
         ) : (
-          <Stack direction="column" gap={2}>
-            <Input
-              ref={searchRef}
-              endDecorator={
-                <IconButton size="sm" onClick={clearSearch}>
-                  <ClearIcon />
-                </IconButton>
-              }
-              onChange={(event) => setSearch(event.target.value)}
-              value={search}
-            />
+          <Stack direction="column" gap={1}>
+            <FormattedMessage
+              id="CardSelect.search.placeholder"
+              defaultMessage="Search..."
+            >
+              {([placeholder]) => (
+                <Input
+                  autoFocus
+                  fullWidth
+                  startDecorator={<SearchIcon />}
+                  endDecorator={
+                    search.length > 0 && (
+                      <IconButton size="sm" onClick={handleClearSearch}>
+                        <ClearIcon />
+                      </IconButton>
+                    )
+                  }
+                  placeholder={placeholder as string}
+                  onChange={(event) => setSearch(event.target.value)}
+                  value={search}
+                />
+              )}
+            </FormattedMessage>
+
+            {search.length > 0 && cardNameOptions.length === 0 && (
+              <Typography level="body-sm" sx={{ mt: 0.5 }}>
+                <FormattedMessage
+                  id="CardSelect.search.noResults"
+                  defaultMessage="No cards found with this name."
+                />
+              </Typography>
+            )}
 
             <List
               sx={(theme) => ({
@@ -286,7 +307,7 @@ const CardSelect = <TCard extends Card>({
             >
               {sortedCardTypes.map((type) => (
                 <ListItem nested key={type}>
-                  {Object.keys(cardNameOptionsByType).length > 1 && (
+                  {showSubheaders && (
                     <ListSubheader sticky>
                       {intl.formatMessage(CardTypeMessages[type].plural)}
                     </ListSubheader>

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -161,6 +161,8 @@
   "CardSelect.header.expansion": "Erweiterung",
   "CardSelect.header.treeSymbol": "Baumsymbol",
   "CardSelect.remove": "Karte entfernen",
+  "CardSelect.search.noResults": "Keine Karten mit diesem Namen gefunden.",
+  "CardSelect.search.placeholder": "Suche...",
   "CardTypes.Alps.plural": "Alpen",
   "CardTypes.Alps.singular": "Alpen",
   "CardTypes.Amphibian.plural": "Amphibien",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -161,6 +161,8 @@
   "CardSelect.header.expansion": "Expansion",
   "CardSelect.header.treeSymbol": "Tree symbol",
   "CardSelect.remove": "Remove card",
+  "CardSelect.search.noResults": "No cards found with this name.",
+  "CardSelect.search.placeholder": "Search...",
   "CardTypes.Alps.plural": "Alps",
   "CardTypes.Alps.singular": "Alps",
   "CardTypes.Amphibian.plural": "Amphibians",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -161,6 +161,8 @@
   "CardSelect.header.expansion": "Uitbreiding",
   "CardSelect.header.treeSymbol": "Boom Symbool",
   "CardSelect.remove": "Kaart verwijderen",
+  "CardSelect.search.noResults": "Geen kaarten gevonden met deze naam.",
+  "CardSelect.search.placeholder": "Zoeken...",
   "CardTypes.Alps.plural": "Alpen",
   "CardTypes.Alps.singular": "Alp",
   "CardTypes.Amphibian.plural": "Amfibieën",

--- a/src/translations/pt-br.json
+++ b/src/translations/pt-br.json
@@ -161,6 +161,8 @@
   "CardSelect.header.expansion": "Expansão",
   "CardSelect.header.treeSymbol": "Símbolo de árvore",
   "CardSelect.remove": "Remover carta",
+  "CardSelect.search.noResults": "Nenhuma carta encontrada com esse nome.",
+  "CardSelect.search.placeholder": "Pesquisar...",
   "CardTypes.Alps.plural": "Alpes",
   "CardTypes.Alps.singular": "Alpes",
   "CardTypes.Amphibian.plural": "Anfíbios",


### PR DESCRIPTION
Thanks for providing this scoring app!

- A search box appears at the top of the `CardSelect` that allows you to type to search through available cards.
- It gets focused automatically when the `CardDrawer` opens.
- Takes localization into account.
- Has a button at the end to clear.

_Disclaimer: I don't have experience with React_